### PR TITLE
Added AWTRIX NG battery percentage support via Homey’s standard `measure_battery` capability and threshold Flow card.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea/
 /.fleet/
 .DS_Store
+AGENTS.md

--- a/docs/awtrix-ng/06-user-maintainer-guide.md
+++ b/docs/awtrix-ng/06-user-maintainer-guide.md
@@ -173,6 +173,7 @@ AWTRIX NG driver mapuje jen doložené a podporované capabilities:
 
 | AWTRIX NG field / endpoint | Homey capability | Poznámka |
 |---|---|---|
+| `batteryPercent` | `measure_battery` | mapuje se hodnota 0–100; capability se přidá jen při init/pairingu, pokud field obsahuje platnou hodnotu |
 | `lowBattery` | `alarm_battery` | mapuje se boolean low-battery stav |
 | `temperature` | `measure_temperature` | přidá se jen při init/pairingu, pokud field existuje |
 | `humidity` | `measure_humidity` | přidá se jen při init/pairingu, pokud field existuje |
@@ -180,10 +181,11 @@ AWTRIX NG driver mapuje jen doložené a podporované capabilities:
 
 Weather overlay capability hodnoty jsou `none`, `drizzle`, `frost`, `rain`, `snow`, `storm`, `thunder`. Změna capability nebo flow action posílá `PATCH /api/v1/display` pouze s polem `overlay`; `overlaySettings` se v první verzi neposílá.
 
+Přítomná hodnota `batteryPercent` v rozsahu 0–100 zpřístupní standardní Homey capability `measure_battery` a její vestavěné Flow cards `measure_battery` a `measure_battery_threshold_below`. Již spárované zařízení ji získá při následujícím initu; polling nové capabilities nepřidává.
+
 Nepodporované v první NG verzi:
 
 - `lightLevel` se nemapuje do `measure_luminance`, protože není v luxech.
-- `batteryPercent` se nemapuje do Homey battery capability; používá se pouze `lowBattery`.
 - `pressureHpa` se nemapuje.
 - Polling nepřidává nové capabilities; pouze aktualizuje capabilities existující na zařízení.
 - `overlaySettings.speed`, `overlaySettings.palette` a `overlaySettings.blend` nejsou v první verzi podporované.

--- a/lib/awtrixng/Device/State.ts
+++ b/lib/awtrixng/Device/State.ts
@@ -12,7 +12,7 @@ export type AwtrixNgHomeyBaseCapabilityId = 'button_prev'
   | 'ip'
   | 'button.rediscover';
 
-export type AwtrixNgHomeyOptionalCapabilityId = 'alarm_battery' | 'measure_temperature' | 'measure_humidity';
+export type AwtrixNgHomeyOptionalCapabilityId = 'measure_battery' | 'alarm_battery' | 'measure_temperature' | 'measure_humidity';
 
 export type AwtrixNgHomeyCapabilityId = AwtrixNgHomeyBaseCapabilityId | AwtrixNgHomeyOptionalCapabilityId;
 
@@ -47,7 +47,18 @@ export const AwtrixNgBaseCapabilityIds: readonly AwtrixNgHomeyBaseCapabilityId[]
   'button.rediscover',
 ];
 
+const isValidBatteryPercent = (value: unknown): value is number => (
+  typeof value === 'number'
+  && Number.isFinite(value)
+  && value >= 0
+  && value <= 100
+);
+
 const optionalCapabilityFields = [{
+  field: 'batteryPercent',
+  capabilityId: 'measure_battery',
+  isValidValue: isValidBatteryPercent,
+}, {
   field: 'lowBattery',
   capabilityId: 'alarm_battery',
   isValidValue: (value: unknown): value is boolean => typeof value === 'boolean',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,20 @@
       "name": "de.blueforcer.awtrixlight",
       "version": "2.2.1",
       "dependencies": {
-        "axios": "^1.5.1",
-        "form-data": "^4.0.0"
+        "axios": "^1.19.0",
+        "form-data": "^4.0.6"
       },
       "devDependencies": {
-        "@tsconfig/node22": "^22.0.0",
-        "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.5",
-        "@types/node": "^22.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.46.0",
-        "@typescript-eslint/parser": "^8.46.0",
+        "@tsconfig/node22": "^22.0.5",
+        "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
+        "@types/node": "^22.20.1",
+        "@typescript-eslint/eslint-plugin": "^8.66.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "eslint": "^8.57.1",
-        "eslint-config-athom": "^3.1.1",
-        "eslint-import-resolver-typescript": "^3.6.1",
-        "eslint-plugin-import": "^2.29.0",
-        "typescript": "^5.2.2"
+        "eslint-config-athom": "^3.1.5",
+        "eslint-import-resolver-typescript": "^4.4.5",
+        "eslint-plugin-import": "^2.32.0",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -292,16 +292,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@nolyfill/is-core-module": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
-      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.4.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -1795,6 +1785,31 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
@@ -1818,22 +1833,22 @@
       }
     },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
-      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+      "integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@nolyfill/is-core-module": "1.0.39",
-        "debug": "^4.4.0",
-        "get-tsconfig": "^4.10.0",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
         "is-bun-module": "^2.0.0",
-        "stable-hash": "^0.0.5",
-        "tinyglobby": "^0.2.13",
-        "unrs-resolver": "^1.6.2"
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^16.17.0 || >=18.6.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint-import-resolver-typescript"
@@ -4185,12 +4200,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/stable-hash": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
-      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,26 +11,26 @@
     "node": ">=22.0.0"
   },
   "devDependencies": {
-    "@tsconfig/node22": "^22.0.0",
-    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.5",
-    "@types/node": "^22.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.46.0",
-    "@typescript-eslint/parser": "^8.46.0",
+    "@tsconfig/node22": "^22.0.5",
+    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.12",
+    "@types/node": "^22.20.1",
+    "@typescript-eslint/eslint-plugin": "^8.66.0",
+    "@typescript-eslint/parser": "^8.66.0",
     "eslint": "^8.57.1",
-    "eslint-config-athom": "^3.1.1",
-    "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-plugin-import": "^2.29.0",
-    "typescript": "^5.2.2"
+    "eslint-config-athom": "^3.1.5",
+    "eslint-import-resolver-typescript": "^4.4.5",
+    "eslint-plugin-import": "^2.32.0",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
-    "axios": "^1.5.1",
-    "form-data": "^4.0.0"
+    "axios": "^1.19.0",
+    "form-data": "^4.0.6"
   },
   "overrides": {
     "eslint-config-athom": {
       "eslint-config-airbnb-base": "^15.0.0",
-      "@typescript-eslint/parser": "^8.46.0",
-      "@typescript-eslint/eslint-plugin": "^8.46.0"
+      "@typescript-eslint/parser": "^8.66.0",
+      "@typescript-eslint/eslint-plugin": "^8.66.0"
     }
   },
   "allowScripts": {

--- a/test/awtrixng-device-state.test.js
+++ b/test/awtrixng-device-state.test.js
@@ -93,6 +93,7 @@ const baseCapabilityValues = [{
 test('AWTRIX NG initial capability ids include base controls and supported optional fields present at init/pairing', () => {
   const deviceState = {
     ...baseDeviceState,
+    batteryPercent: 0,
     lowBattery: false,
     temperature: 22.5,
     humidity: 45,
@@ -100,16 +101,16 @@ test('AWTRIX NG initial capability ids include base controls and supported optio
 
   assert.deepEqual(getAwtrixNgInitialCapabilityIds(deviceState), [
     ...AwtrixNgBaseCapabilityIds,
+    'measure_battery',
     'alarm_battery',
     'measure_temperature',
     'measure_humidity',
   ]);
 });
 
-test('AWTRIX NG initial capability ids ignore unsupported and non-mapped fields', () => {
+test('AWTRIX NG initial capability ids ignore unsupported fields', () => {
   const deviceState = {
     ...baseDeviceState,
-    batteryPercent: 82,
     pressureHpa: 1013,
     lightLevel: 80,
   };
@@ -135,6 +136,7 @@ test('AWTRIX NG capability plan adds base controls and supported optional values
   }), {
     capabilitiesToAdd: [
       ...AwtrixNgBaseCapabilityIds,
+      'measure_battery',
       'alarm_battery',
       'measure_temperature',
       'measure_humidity',
@@ -142,6 +144,9 @@ test('AWTRIX NG capability plan adds base controls and supported optional values
     valuesToSet: [
       ...baseCapabilityValues,
       {
+        capabilityId: 'measure_battery',
+        value: 82,
+      }, {
         capabilityId: 'alarm_battery',
         value: true,
       }, {
@@ -155,15 +160,36 @@ test('AWTRIX NG capability plan adds base controls and supported optional values
   });
 });
 
+test('AWTRIX NG capability plan migrates measure_battery for an existing device during init', () => {
+  const deviceState = {
+    ...baseDeviceState,
+    batteryPercent: 82,
+  };
+
+  assert.deepEqual(createAwtrixNgCapabilityUpdatePlan(deviceState, AwtrixNgBaseCapabilityIds, {
+    allowAddCapabilities: true,
+  }), {
+    capabilitiesToAdd: ['measure_battery'],
+    valuesToSet: [
+      ...baseCapabilityValues,
+      {
+        capabilityId: 'measure_battery',
+        value: 82,
+      },
+    ],
+  });
+});
+
 test('AWTRIX NG capability plan does not add capabilities during polling', () => {
   const deviceState = {
     ...baseDeviceState,
+    batteryPercent: 100,
     lowBattery: false,
     temperature: 22.5,
     humidity: 45,
   };
 
-  assert.deepEqual(createAwtrixNgCapabilityUpdatePlan(deviceState, ['alarm_battery', 'awtrix_matrix', 'rssi', 'ip'], {
+  assert.deepEqual(createAwtrixNgCapabilityUpdatePlan(deviceState, ['measure_battery', 'alarm_battery', 'awtrix_matrix', 'rssi', 'ip'], {
     allowAddCapabilities: false,
   }), {
     capabilitiesToAdd: [],
@@ -177,15 +203,33 @@ test('AWTRIX NG capability plan does not add capabilities during polling', () =>
       capabilityId: 'ip',
       value: '192.168.1.44',
     }, {
+      capabilityId: 'measure_battery',
+      value: 100,
+    }, {
       capabilityId: 'alarm_battery',
       value: false,
     }],
   });
 });
 
+test('AWTRIX NG capability plan skips a newly detected battery measurement during polling', () => {
+  const plan = createAwtrixNgCapabilityUpdatePlan({
+    ...baseDeviceState,
+    batteryPercent: 50,
+  }, AwtrixNgBaseCapabilityIds, {
+    allowAddCapabilities: false,
+  });
+
+  assert.deepEqual(plan, {
+    capabilitiesToAdd: [],
+    valuesToSet: baseCapabilityValues,
+  });
+});
+
 test('AWTRIX NG capability plan skips missing optional fields instead of writing null or zero', () => {
   assert.deepEqual(createAwtrixNgCapabilityUpdatePlan(baseDeviceState, [
     ...AwtrixNgBaseCapabilityIds,
+    'measure_battery',
     'alarm_battery',
     'measure_temperature',
     'measure_humidity',
@@ -195,4 +239,18 @@ test('AWTRIX NG capability plan skips missing optional fields instead of writing
     capabilitiesToAdd: [],
     valuesToSet: baseCapabilityValues,
   });
+});
+
+test('AWTRIX NG capability plan skips battery percentages outside Homey\'s 0-100 range', () => {
+  for (const batteryPercent of [-1, 101, Number.NaN, Number.POSITIVE_INFINITY]) {
+    const plan = createAwtrixNgCapabilityUpdatePlan({
+      ...baseDeviceState,
+      batteryPercent,
+    }, [], {
+      allowAddCapabilities: true,
+    });
+
+    assert.equal(plan.capabilitiesToAdd.includes('measure_battery'), false);
+    assert.equal(plan.valuesToSet.some((update) => update.capabilityId === 'measure_battery'), false);
+  }
 });


### PR DESCRIPTION
…to prevent broken/un-fixable flows ;-)